### PR TITLE
Add flexible transaction reconciliation utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,6 @@ File specifications are of the form `path[:amount_col[:date_col[:description_col
 * `--start YYYY-MM-DD` and `--end YYYY-MM-DD` – limit reconciliation to a time period. If omitted the statement's date range is used.
 * `--allow-combined` – enable matching where several ledger entries combine into one statement charge.
 * `--statement-charges-positive` – set if the statement lists charges as positive amounts. By default charges are assumed negative and are flipped for matching.
+* `--only-statement` – show only transactions that appear exclusively on the statement; unmatched list transactions are summarized.
 
 Matching is based solely on transaction amounts, ignoring dates and descriptions. The tool reports transactions that appear only on the statement or only in the provided lists and prints all columns for easy inspection.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # reconciler
-Reconciles lists of transactions with credit card data
+
+Reconciles lists of transactions with credit card data.
+
+## Usage
+
+The project exposes a small command line interface. Invoke it with `python -m reconciler.cli` and provide at least one transaction file and a credit card statement:
+
+```bash
+python -m reconciler.cli \
+  --transactions purchases.csv:Total:Date:Description \
+  --statement statement.csv:Amount:Date:Description
+```
+
+File specifications are of the form `path[:amount_col[:date_col[:description_col]]]`. This allows files with differing column names to be handled. Multiple `--transactions` options may be supplied to combine several sources.
+
+### Options
+
+* `--ignore TEXT` – ignore statement rows whose description contains the given text. May be repeated.
+* `--start YYYY-MM-DD` and `--end YYYY-MM-DD` – limit reconciliation to a time period. If omitted the statement's date range is used.
+* `--allow-combined` – enable matching where several ledger entries combine into one statement charge.
+* `--statement-charges-positive` – set if the statement lists charges as positive amounts. By default charges are assumed negative and are flipped for matching.
+
+Matching is based solely on transaction amounts, ignoring dates and descriptions. The tool reports transactions that appear only on the statement or only in the provided lists and prints all columns for easy inspection.

--- a/reconciler/__init__.py
+++ b/reconciler/__init__.py
@@ -1,0 +1,12 @@
+"""Reconciliation utility package."""
+
+from .loader import Transaction, load_transactions
+from .matcher import ExactMatcher, CombinedMatcher, reconcile
+
+__all__ = [
+    'Transaction',
+    'load_transactions',
+    'ExactMatcher',
+    'CombinedMatcher',
+    'reconcile',
+]

--- a/reconciler/cli.py
+++ b/reconciler/cli.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import replace
+from datetime import datetime
+from typing import List, Sequence
+
+from .loader import load_transactions, Transaction
+from .matcher import CombinedMatcher, ExactMatcher, reconcile
+
+
+def parse_file_spec(spec: str):
+    """Parse file specification of the form path[:amount[:date[:description]]]."""
+    parts = spec.split(":")
+    path = parts[0]
+    amount_col = parts[1] if len(parts) > 1 and parts[1] else "Amount"
+    date_col = parts[2] if len(parts) > 2 and parts[2] else "Date"
+    description_col = parts[3] if len(parts) > 3 and parts[3] else "Description"
+    return path, amount_col, date_col, description_col
+
+
+def load_from_specs(specs: Sequence[str]) -> List[Transaction]:
+    txns: List[Transaction] = []
+    for spec in specs:
+        path, amount, date_col, desc = parse_file_spec(spec)
+        txns.extend(load_transactions(path, amount, date_col, desc))
+    return txns
+
+
+def filter_transactions(
+    transactions: Sequence[Transaction],
+    start: datetime | None,
+    end: datetime | None,
+    ignore: Sequence[str],
+) -> List[Transaction]:
+    result: List[Transaction] = []
+    for tx in transactions:
+        if start and tx.date and tx.date < start.date():
+            continue
+        if end and tx.date and tx.date > end.date():
+            continue
+        desc_lower = tx.description.lower()
+        if any(word.lower() in desc_lower for word in ignore):
+            continue
+        result.append(tx)
+    return result
+
+
+def print_transactions(transactions: Sequence[Transaction]):
+    if not transactions:
+        print("  None")
+        return
+    # determine all columns
+    columns = sorted({col for tx in transactions for col in tx.data.keys()})
+    widths = {col: max(len(col), *(len(tx.data.get(col, "")) for tx in transactions)) for col in columns}
+    header = " | ".join(col.ljust(widths[col]) for col in columns)
+    divider = "-+-".join("-" * widths[col] for col in columns)
+    print(header)
+    print(divider)
+    for tx in transactions:
+        row = " | ".join(tx.data.get(col, "").ljust(widths[col]) for col in columns)
+        print(row)
+
+
+def main(argv: Sequence[str] | None = None):
+    parser = argparse.ArgumentParser(description="Reconcile transactions with a credit card statement")
+    parser.add_argument(
+        "--transactions",
+        action="append",
+        required=True,
+        help="Transaction file specification: path[:amount_col[:date_col[:description_col]]]",
+    )
+    parser.add_argument(
+        "--statement",
+        required=True,
+        help="Credit card statement file specification: path[:amount_col[:date_col[:description_col]]]",
+    )
+    parser.add_argument("--ignore", action="append", default=[], help="Ignore statement rows containing this text")
+    parser.add_argument("--start", help="Start date YYYY-MM-DD")
+    parser.add_argument("--end", help="End date YYYY-MM-DD")
+    parser.add_argument("--allow-combined", action="store_true", help="Allow matching combined charges")
+    parser.add_argument(
+        "--statement-charges-positive",
+        action="store_true",
+        help="Statement lists charges as positive amounts (default assumes negatives)",
+    )
+
+    args = parser.parse_args(argv)
+
+    statement_path, s_amount, s_date, s_desc = parse_file_spec(args.statement)
+    statement = load_transactions(statement_path, s_amount, s_date, s_desc)
+    if not args.statement_charges_positive:
+        statement = [replace(tx, amount=-tx.amount) for tx in statement]
+    statement = [tx for tx in statement if tx.amount >= 0]
+
+    transactions = load_from_specs(args.transactions)
+
+    # Determine date range
+    start = datetime.fromisoformat(args.start) if args.start else None
+    end = datetime.fromisoformat(args.end) if args.end else None
+    if not start or not end:
+        stmt_dates = [tx.date for tx in statement if tx.date]
+        if stmt_dates:
+            if not start:
+                start = datetime.combine(min(stmt_dates), datetime.min.time())
+            if not end:
+                end = datetime.combine(max(stmt_dates), datetime.min.time())
+
+    statement = filter_transactions(statement, start, end, args.ignore)
+    transactions = filter_transactions(transactions, start, end, [])
+
+    matcher = CombinedMatcher() if args.allow_combined else ExactMatcher()
+    matched, only_statement, only_ledger = reconcile(statement, transactions, matcher)
+
+    if not only_statement and not only_ledger:
+        print("All transactions match")
+        return
+    if only_statement:
+        print("Transactions only on credit card statement:")
+        print_transactions(only_statement)
+    if only_ledger:
+        print("Transactions only on provided lists:")
+        print_transactions(only_ledger)
+
+
+if __name__ == "__main__":
+    main()

--- a/reconciler/cli.py
+++ b/reconciler/cli.py
@@ -84,6 +84,11 @@ def main(argv: Sequence[str] | None = None):
         action="store_true",
         help="Statement lists charges as positive amounts (default assumes negatives)",
     )
+    parser.add_argument(
+        "--only-statement",
+        action="store_true",
+        help="Only show transactions that are extra on the statement",
+    )
 
     args = parser.parse_args(argv)
 
@@ -114,6 +119,13 @@ def main(argv: Sequence[str] | None = None):
 
     if not only_statement and not only_ledger:
         print("All transactions match")
+        return
+    if args.only_statement:
+        if only_statement:
+            print("Transactions only on credit card statement:")
+            print_transactions(only_statement)
+        if only_ledger:
+            print(f"{len(only_ledger)} transactions only on provided lists")
         return
     if only_statement:
         print("Transactions only on credit card statement:")

--- a/reconciler/loader.py
+++ b/reconciler/loader.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import csv
+import os
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime, date
+from decimal import Decimal, InvalidOperation
+from typing import Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class Transaction:
+    """Represents a single transaction.
+
+    Attributes
+    ----------
+    data: Raw column mapping for the transaction. Used for pretty printing.
+    amount: Paid amount for the transaction.
+    date: Parsed date if available.
+    description: Human readable description for filtering and matching.
+    """
+
+    data: Dict[str, str]
+    amount: Decimal
+    date: Optional[date]
+    description: str
+
+    def key(self) -> Decimal:
+        """Return the key used for matching transactions.
+
+        Matching only considers the amount, ignoring dates or descriptions
+        which often differ between the ledger and the statement.
+        """
+        return self.amount
+
+
+class TransactionLoader(ABC):
+    """Abstract loader interface to support different file formats."""
+
+    @abstractmethod
+    def load(
+        self,
+        path: str,
+        amount_col: str,
+        date_col: Optional[str] = None,
+        description_col: Optional[str] = None,
+    ) -> List[Transaction]:
+        raise NotImplementedError
+
+
+class CSVLoader(TransactionLoader):
+    """Loads transactions from a CSV file."""
+
+    def load(
+        self,
+        path: str,
+        amount_col: str,
+        date_col: Optional[str] = None,
+        description_col: Optional[str] = None,
+    ) -> List[Transaction]:
+        with open(path, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            txns: List[Transaction] = []
+            for row in reader:
+                amount_raw = row.get(amount_col, "0")
+                try:
+                    amount = Decimal(amount_raw)
+                except (InvalidOperation, TypeError):
+                    continue
+                date_val: Optional[date] = None
+                if date_col and row.get(date_col):
+                    try:
+                        date_val = datetime.fromisoformat(row[date_col]).date()
+                    except ValueError:
+                        pass
+                description = row.get(description_col or "Description", "")
+                txns.append(Transaction(row, amount, date_val, description))
+        return txns
+
+
+LOADERS = {
+    ".csv": CSVLoader(),
+}
+
+
+def get_loader(path: str) -> TransactionLoader:
+    """Return a loader instance based on file extension."""
+    _, ext = os.path.splitext(path.lower())
+    if ext in LOADERS:
+        return LOADERS[ext]
+    raise ValueError(f"Unsupported file extension: {ext}")
+
+
+def load_transactions(
+    path: str,
+    amount_col: str,
+    date_col: Optional[str] = None,
+    description_col: Optional[str] = None,
+) -> List[Transaction]:
+    """Convenience wrapper for loading transactions."""
+    loader = get_loader(path)
+    return loader.load(path, amount_col, date_col, description_col)

--- a/reconciler/matcher.py
+++ b/reconciler/matcher.py
@@ -42,7 +42,7 @@ class ExactMatcher(Matcher):
 
 
 class CombinedMatcher(ExactMatcher):
-    """Matcher that allows combining multiple ledger entries to match a statement."""
+    """Matcher that allows combining multiple statement entries to match a ledger entry."""
 
     def match(
         self, statement: Sequence[Transaction], ledger: Sequence[Transaction]
@@ -51,16 +51,16 @@ class CombinedMatcher(ExactMatcher):
         if not statement_only or not ledger_only:
             return matched, statement_only, ledger_only
 
-        remaining_statement: List[Transaction] = []
-        remaining_ledger = ledger_only[:]
-        for st in statement_only:
-            combo = _find_combination(remaining_ledger, st)
+        remaining_statement = statement_only[:]
+        remaining_ledger: List[Transaction] = []
+        for le in ledger_only:
+            combo = _find_combination(remaining_statement, le)
             if combo:
                 for item in combo:
-                    remaining_ledger.remove(item)
-                matched.append((st, combo))
+                    remaining_statement.remove(item)
+                matched.append((le, combo))
             else:
-                remaining_statement.append(st)
+                remaining_ledger.append(le)
         return matched, remaining_statement, remaining_ledger
 
 

--- a/reconciler/matcher.py
+++ b/reconciler/matcher.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from decimal import Decimal
+from typing import List, Sequence, Tuple
+
+from .loader import Transaction
+
+
+class Matcher(ABC):
+    """Interface for reconciling two transaction lists."""
+
+    @abstractmethod
+    def match(
+        self, statement: Sequence[Transaction], ledger: Sequence[Transaction]
+    ) -> Tuple[List[Tuple[Transaction, Sequence[Transaction]]], List[Transaction], List[Transaction]]:
+        """Return a tuple of (matched, only_statement, only_ledger)."""
+        raise NotImplementedError
+
+
+class ExactMatcher(Matcher):
+    """Performs one-to-one exact matching based on transaction keys."""
+
+    def match(
+        self, statement: Sequence[Transaction], ledger: Sequence[Transaction]
+    ) -> Tuple[List[Tuple[Transaction, Sequence[Transaction]]], List[Transaction], List[Transaction]]:
+        ledger_map = defaultdict(list)
+        for txn in ledger:
+            ledger_map[txn.key()].append(txn)
+
+        matched: List[Tuple[Transaction, Sequence[Transaction]]] = []
+        statement_only: List[Transaction] = []
+        for st in statement:
+            key = st.key()
+            if ledger_map[key]:
+                matched.append((st, [ledger_map[key].pop(0)]))
+            else:
+                statement_only.append(st)
+        ledger_only = [tx for txns in ledger_map.values() for tx in txns]
+        return matched, statement_only, ledger_only
+
+
+class CombinedMatcher(ExactMatcher):
+    """Matcher that allows combining multiple ledger entries to match a statement."""
+
+    def match(
+        self, statement: Sequence[Transaction], ledger: Sequence[Transaction]
+    ) -> Tuple[List[Tuple[Transaction, Sequence[Transaction]]], List[Transaction], List[Transaction]]:
+        matched, statement_only, ledger_only = super().match(statement, ledger)
+        if not statement_only or not ledger_only:
+            return matched, statement_only, ledger_only
+
+        remaining_statement: List[Transaction] = []
+        remaining_ledger = ledger_only[:]
+        for st in statement_only:
+            combo = _find_combination(remaining_ledger, st)
+            if combo:
+                for item in combo:
+                    remaining_ledger.remove(item)
+                matched.append((st, combo))
+            else:
+                remaining_statement.append(st)
+        return matched, remaining_statement, remaining_ledger
+
+
+def _find_combination(ledger: List[Transaction], target: Transaction) -> List[Transaction]:
+    """Return a subset of ledger transactions whose amounts sum to the target."""
+    candidates = ledger
+    max_items = min(5, len(candidates))
+    from itertools import combinations
+
+    for r in range(2, max_items + 1):
+        for combo in combinations(candidates, r):
+            total = sum((tx.amount for tx in combo), Decimal("0"))
+            if total == target.amount:
+                return list(combo)
+    return []
+
+
+def reconcile(
+    statement: Sequence[Transaction],
+    ledger: Sequence[Transaction],
+    matcher: Matcher | None = None,
+):
+    matcher = matcher or ExactMatcher()
+    return matcher.match(statement, ledger)

--- a/tests/data/ledger.csv
+++ b/tests/data/ledger.csv
@@ -1,0 +1,5 @@
+Date,Description,Amount
+2023-01-01,Coffee Shop,3.50
+2023-01-02,Grocery,4.00
+2023-01-02,Grocery,6.00
+2023-01-03,Online Store,15.00

--- a/tests/data/statement.csv
+++ b/tests/data/statement.csv
@@ -1,0 +1,4 @@
+Date,Description,Amount
+2023-01-01,Coffee Shop,-3.50
+2023-01-02,Grocery,-10.00
+2023-01-03,Online Store,-15.00

--- a/tests/data/statement.csv
+++ b/tests/data/statement.csv
@@ -1,4 +1,4 @@
-Date,Description,Amount
-2023-01-01,Coffee Shop,-3.50
-2023-01-02,Grocery,-10.00
-2023-01-03,Online Store,-15.00
+Date,Description,Amount,Type
+2023-01-01,Coffee Shop,-3.50,Sale
+2023-01-02,Grocery,-10.00,Sale
+2023-01-03,Online Store,-15.00,Sale

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,24 @@
+import subprocess
+import sys
+
+
+def test_cli_only_statement_shows_summary(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "reconciler.cli",
+            "--transactions",
+            "tests/data/ledger.csv",
+            "--statement",
+            "tests/data/statement.csv",
+            "--only-statement",
+        ],
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0
+    out = result.stdout
+    assert "Transactions only on credit card statement:" in out
+    assert "Transactions only on provided lists:" not in out
+    assert "2 transactions only on provided lists" in out

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -1,0 +1,46 @@
+from dataclasses import replace
+from decimal import Decimal
+
+from reconciler.loader import load_transactions
+from reconciler.matcher import CombinedMatcher, ExactMatcher
+
+
+def test_exact_matcher_separates_unmatched_transactions():
+    statement = load_transactions(
+        "tests/data/statement.csv", "Amount", "Date", "Description"
+    )
+    statement = [replace(tx, amount=-tx.amount) for tx in statement]
+    ledger = load_transactions(
+        "tests/data/ledger.csv", "Amount", "Date", "Description"
+    )
+    matcher = ExactMatcher()
+    matched, only_statement, only_ledger = matcher.match(statement, ledger)
+
+    assert len(matched) == 2
+    assert [tx.description for tx, _ in matched] == ["Coffee Shop", "Online Store"]
+    assert [tx.description for tx in only_statement] == ["Grocery"]
+    assert [tx.description for tx in only_ledger] == ["Grocery", "Grocery"]
+
+
+def test_combined_matcher_matches_split_transactions():
+    statement = load_transactions(
+        "tests/data/statement.csv", "Amount", "Date", "Description"
+    )
+    statement = [replace(tx, amount=-tx.amount) for tx in statement]
+    ledger = load_transactions(
+        "tests/data/ledger.csv", "Amount", "Date", "Description"
+    )
+    matcher = CombinedMatcher()
+    matched, only_statement, only_ledger = matcher.match(statement, ledger)
+
+    assert len(matched) == 3
+    assert not only_statement
+    assert not only_ledger
+
+    grocery_match = next(
+        (combo for st, combo in matched if st.description == "Grocery"), None
+    )
+    assert grocery_match is not None
+    amounts = sorted(tx.amount for tx in grocery_match)
+    assert amounts == [Decimal("4.00"), Decimal("6.00")]
+    assert all(isinstance(tx.amount, Decimal) for st, combo in matched for tx in [st, *combo])


### PR DESCRIPTION
## Summary
- use `Decimal` amounts to avoid float rounding issues during reconciliation
- add unit tests and sample CSV files covering exact and combined matching
- match transactions solely by amount and support negative statement charges via `--statement-charges-positive`

## Testing
- `python -m py_compile reconciler/__init__.py reconciler/loader.py reconciler/matcher.py reconciler/cli.py`
- `python -m reconciler.cli --help`
- `python -m pytest -q`